### PR TITLE
#157630817 User declined requests page

### DIFF
--- a/UI/user_cancelled_dashboard.html
+++ b/UI/user_cancelled_dashboard.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>M-Tracker - DashBoard</title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="./assets/css/dashboard.css" />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+
+
+</head>
+    <body>
+        <div class="topnav">
+            <p>M-Tracker</p>
+            
+            <a href="login.html">Logout</a>
+            <a href="#">Profile</a>
+            <a href="user_dashboard.html">Home</a>
+            <a href="#"><i class="material-icons notify-icon">mms</i><b class="notify-count">2</b></a>
+
+        </div>
+        <p >
+            <h4  class="dashboard-heading">User Dashboard</h4>
+            <p>
+                    <img src="./assets/images/profile_photo.png" class="profile-photo" />
+            </p>
+            <h5 class="welcome-msg" >Welcome User,</h5>
+        </p>
+        <h4 class="resolved-request-header"><img src="./assets/images/log-icon.png" class="resolved-request-header-photo"/> Declined Requests</h4>
+        <p class="form-footer">
+                
+            Also view: <a href="user_dashboard.html" class="formLinkColor">.. 1. My Requests...</a>
+            <a href="user_pending_dashboard.html" class="formLinkColor">..2. Pending Requests...</a>
+            <a href="user_cancelled_dashboard.html" class="formLinkColor">..3. Cancelled Requests...</a>
+           
+         </p>
+    
+         <p >
+                 <a href="create_request_user.html"><button class="create-button">Create-A-Request</button></a>
+         </p>
+        <table>
+           
+                <thead>
+                  <tr>
+                    <th>S/N</th>
+                    <th>Request ID</th>
+                    <th>Title</th>
+                    <th>Description</th>
+                    <th>Date</th>
+                    <th>Priority</th>
+                    <th>Action</th>
+                    
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td data-column="S/N">1</td>
+                    <td data-column="Request ID">2356</td>
+                    <td data-column="Title">System repairs</td>
+                    <td data-column="Description">The matman request</td>
+                    <td data-column="Date">2018-16-05</td>
+                    <td data-column="Priority">High</td>
+                    <td data-column="Action"><b>DECLINED</b></td>
+
+                  </tr>
+                 
+                </tbody>
+              </table>
+        
+     
+        <p class="footer">© 2018. M-tracker.</p>
+       
+        <script>
+            
+        </script>
+
+    </body>
+</html>


### PR DESCRIPTION
#### What does this PR do?
Create a page for the user to view all declined requests

#### Description of Task to be completed?
User should be able to navigate to the declined requests page and view all requests that were declined
The page is developed using the HTML, CSS, JS stack

#### Any background context you want to provide?
none

####  What are the relevant pivotal tracker stories?
story type: feature
story id: 157630817

#### What are the relevant Github Issues?
None

#### Questions:
None

#### Desktop view
![user_declined](https://user-images.githubusercontent.com/5827585/40267672-99e84e78-5b58-11e8-88e3-0b1970258083.PNG)

#### Mobile view
![user_declined_m](https://user-images.githubusercontent.com/5827585/40267674-a364a0e6-5b58-11e8-82c2-529290d05b2c.PNG)



