### PR TITLE
#157626907 Admin Pending Request Page

### DIFF
--- a/UI/admin_pending_dashboard.html
+++ b/UI/admin_pending_dashboard.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>M-Tracker - DashBoard</title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="./assets/css/dashboard.css" />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+
+
+</head>
+    <body>
+        <div class="topnav">
+            <p>M-Tracker</p>
+            
+            <a href="admin_login.html">Logout</a>
+            <a href="#">Profile</a>
+            <a href="admin_dashboard.html">Home</a>
+            <a href="#"><i class="material-icons notify-icon">mms</i><b class="notify-count">2</b></a>
+
+        </div>
+        <p >
+            <h4  class="dashboard-heading">Admin Dashboard</h4>
+            <p>
+                    <img src="./assets/images/profile_photo.png" class="profile-photo" />
+            </p>
+            <h5 class="welcome-msg" >Welcome Admin,</h5>
+        </p>
+        <h4 class="resolved-request-header"><img src="./assets/images/log-icon.png" class="resolved-request-header-photo"/> Pending Requests</h4>
+        <p class="form-footer">
+                
+            Also view: <a href="admin_dashboard.html" class="formLinkColor">.. 1. My Requests...</a>
+            <a href="admin_pending_dashboard.html" class="formLinkColor">..2. Pending Requests...</a>
+            <a href="admin_cancelled_dashboard.html" class="formLinkColor">..3. Cancelled Requests...</a>
+           
+         </p>
+    
+        <div align="center">
+          <input type="text" id="myFilter" onkeyup="myFilterTableFunction()" placeholder="Filter by names,ID,title..." title="Type in a name">
+        </div>
+
+        <table id="request-table">
+                <thead>
+                  <tr>
+                    <th>S/N</th>
+                    <th>Requester</th>
+                    <th>Request ID</th>
+                    <th>Title</th>
+                    <th>Description</th>
+                    <th>Priority</th>
+                    <th>Action</th>
+                    
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td data-column="S/N">1</td>
+                    <td data-column="Requester">Matman</td>
+                    <td data-column="Requester ID">2356</td>
+                    <td data-column="Title">AC Repair job</td>                    
+                    <td data-column="Description">The matman request</td>
+                    <td data-column="Priority">High</td>
+                    <td data-column="Action"><a href="view_resolve_admin.html"><button class="resolve-button" onclick=" ">Resolve Request</button></a></td>
+
+                  </tr>
+                 
+                </tbody>
+              </table>
+     
+
+        <p class="footer">© 2018. M-tracker.</p>
+    
+        
+        <script src="./assets/js/script.js">
+            
+        </script>
+
+    </body>
+</html>


### PR DESCRIPTION
#### What does this PR do?
Create a page for the admin to view all requests on pending but yet to be finally resolved

#### Description of Task to be completed?
Admin should be able to navigate to the pending requests page and view all pending requests page 
Admin should be filter the requests using the search filter box 
The page is developed using the HTML, CSS, JS stack

#### Any background context you want to provide?
none

####  What are the relevant pivotal tracker stories?
story type: feature
story id: 157626907

#### What are the relevant Github Issues?
None

#### Questions:
None

#### Desktop view
![admin_pending](https://user-images.githubusercontent.com/5827585/40271547-710a2da8-5b96-11e8-9269-5aa1e6f6acd0.PNG)

#### Mobile view
![admin_pending_m](https://user-images.githubusercontent.com/5827585/40271554-79c0b9f8-5b96-11e8-84a3-3d3a05efe9a3.PNG)
