### PR TITLE
#157573289 Admin Request Details Page

### DIFF
--- a/UI/view_request_admin.html
+++ b/UI/view_request_admin.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>M-Tracker - DashBoard</title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="./assets/css/pages.css" />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+
+
+</head>
+    <body>
+        <div class="topnav">
+            <p>M-Tracker</p>
+            
+            <a href="admin_login.html">Logout</a>
+            <a href="#">Profile</a>
+            <a href="admin_dashboard.html">Home</a>
+            <a href="#"><i class="material-icons notify-icon">mms</i><b class="notify-count">2</b></a>
+
+        </div>
+        <h4 ><img src="./assets/images/details.png" class="page-icon" /></h4>
+        <h4 class="resolved-request-header">
+            Request Details
+        </h4>
+        <p class="form-footer">
+                
+                <a href="admin_dashboard.html" class="formLinkColor">...Back to Request Logs...</a>
+           
+         </p>
+         <div id="container">
+          
+          <div class="approve-category-panel"> 
+            Request Approved! Check pending request to resolve.
+          </div>
+          <div class="decline-category-panel"> 
+              Request Declined! Requester will be notified shortly.
+            </div>
+          
+ 
+          <div class="details-container" id="request-details-box">
+              
+              <p class="categoryPanelHeader">
+                <b>
+                  ID:
+                </b>
+                23456
+              </p>
+              <p class="categoryPanelHeader">
+                <b>
+                  Requester Name:
+                </b>
+                Yomi Olaoye
+              </p>
+              <p class="categoryPanelHeader">
+                <b>
+                  Unit/Department:
+                </b>
+                Technology
+              </p>
+              <p class="categoryPanelHeader">
+                  <b>
+                    Title:
+                  </b>
+                  Repair the office AC
+                </p>
+              <p class="categoryPanelHeader">
+                <b>
+                  Description:
+                </b>
+                Reapair system Operating system
+              </p>
+              <p class="categoryPanelHeader">
+                <b>
+                  Priority:
+                </b>
+                High
+              </p>
+            
+              
+              
+              <div >
+                  <button class="approve-button" id="submit" onclick="approvePanelShow() ">Approve</button>
+                  <button class="decline-button" id="submit" onclick="declinePanelShow() ">Decline</button>
+              </div>
+            </div>
+         
+      
+      </div>
+
+        <p class="footer">© 2018. M-tracker.</p>
+                 
+        <script src="./assets/js/script.js">
+            
+        </script>
+
+    </body>
+</html>


### PR DESCRIPTION
#### What does this PR do?
Create a page for the admin to view a request details

#### Description of Task to be completed?
Admin should be able to navigate to each request details page so as to further with a decision of approval or decline
Admin should be able to view details about the request on the page
Admin should be able to also click an approve or decline button on the request details page
The page is developed using the HTML, CSS, JS stack

#### Any background context you want to provide?
none

####  What are the relevant pivotal tracker stories?
story type: feature
story id: 157573289

#### What are the relevant Github Issues?
None

#### Questions:
None

#### Desktop view
![admin_request](https://user-images.githubusercontent.com/5827585/40274972-5d074fca-5bdc-11e8-90a2-c6a39cdbeec5.PNG)

#### Mobile view
![admin_request_m](https://user-images.githubusercontent.com/5827585/40274977-67ebfba2-5bdc-11e8-9e5c-cd14b075fb8f.PNG)

