### PR TITLE
#157573770 Request Confirm Page

### DIFF
--- a/UI/view_resolve_admin.html
+++ b/UI/view_resolve_admin.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>M-Tracker - DashBoard</title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="./assets/css/pages.css" />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+
+
+</head>
+    <body>
+        <div class="topnav">
+            <p>M-Tracker</p>
+            
+            <a href="admin_login.html">Logout</a>
+            <a href="#">Profile</a>
+            <a href="admin_dashboard.html">Home</a>
+            <a href="#"><i class="material-icons notify-icon">mms</i><b class="notify-count">2</b></a>
+
+        </div>
+        <h4 ><img src="./assets/images/details.png" class="page-icon" /></h4>
+        <h4 class="resolved-request-header">
+            Confirm Request
+        </h4>
+        <div class="approve-category-panel"> 
+          Request Resolved!
+        </div>
+        <p class="form-footer">
+                
+                <a href="admin_dashboard.html" class="formLinkColor">...Back to Request Logs...</a>
+           
+         </p>
+          <div class="details-container" id="request-details-box">
+              
+              <p class="categoryPanelHeader">
+                <b>
+                  ID:
+                </b>
+                23456
+              </p>
+              <p class="categoryPanelHeader">
+                <b>
+                  Requester Name:
+                </b>
+                Yomi Olaoye
+              </p>
+              <p class="categoryPanelHeader">
+                  <b>
+                    Title:
+                  </b>
+                  AC repair
+                </p>
+              <p class="categoryPanelHeader">
+                <b>
+                  Description:
+                </b>
+                Reapair system Operating system
+              </p>
+             
+              <p class="categoryPanelHeader">
+                <b>
+                  Priority:
+                </b>
+                High
+              </p>
+        
+              <div >
+                <h5>Are you sure you want to resolve the request?</h4>
+               
+                  <button class="approve-button" onclick="approveResolvePanelShow()">Yes</button>
+                  <a href="admin_pending_dashboard.html"><button class="decline-button" id="submit" onclick="">No</button></a>
+              </div>
+            </div>
+      
+      </div>
+
+        <p class="footer">© 2018. M-tracker.</p>
+ 
+        <script src="./assets/js/script.js">
+            
+        </script>
+
+    </body>
+</html>


### PR DESCRIPTION
#### What does this PR do?
Create a page for the admin to confirm or decline a request resolution

#### Description of Task to be completed?
Admin should be able to navigate to the request resolve confirm page from pending requests dashboard page
Admin should be able to click the 'yes' or 'no' button on decision
The page is developed using the HTML, CSS, JS stack

#### Any background context you want to provide?
none

####  What are the relevant pivotal tracker stories?
story type: feature
story id: 157573770

#### What are the relevant Github Issues?
None

#### Questions:
None

#### Desktop view
![admin_confirm_b](https://user-images.githubusercontent.com/5827585/40275204-edf2b12e-5be0-11e8-8beb-47ddee31713c.PNG)

#### Mobile view
![admin_confirm_m](https://user-images.githubusercontent.com/5827585/40275205-f56a7b76-5be0-11e8-8d03-3e77cb72f13b.PNG)

