### PR TITLE
#157754772 Admin Disapprove Request API

### DIFF
--- a/server/controllers/AdminRequestController.js
+++ b/server/controllers/AdminRequestController.js
@@ -33,7 +33,7 @@ class AdminRequestController {
     const requestProcessByAdmin = res.locals.value;
     const approveDbQuery = (`UPDATE requests SET status = ${2}  WHERE id = '${req.params.requestId}' AND status = ${1} RETURNING *`);
 
-    const declineDbQuery = (`UPDATE requests SET status = ${3}  WHERE id = '${req.params.requestId}' AND status = ${1} RETURNING *`);
+    const declineDbQuery = (`UPDATE requests SET status = ${3}  WHERE id = '${req.params.requestId}' AND (status = ${1} OR status = ${2}) RETURNING *`);
 
     const resolveDbQuery = (`UPDATE requests SET status = ${4}  WHERE id = '${req.params.requestId}' AND status = ${2} RETURNING *`);
 

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -51,6 +51,12 @@ routes.put(
   CheckRequest.existingRequest, RequestTypeSelector.approve,
   AdminRequestController.adminRequestProcess,
 );
+// Disapprove User Request
+routes.put(
+  '/requests/:requestId/disapprove', auth, CheckRole.checkIfAdmin,
+  CheckRequest.existingRequest, RequestTypeSelector.decline,
+  AdminRequestController.adminRequestProcess,
+);
 
 
 export default routes;

--- a/server/test/adminRequests.js
+++ b/server/test/adminRequests.js
@@ -57,6 +57,22 @@ describe('Admin request API Tests', () => {
       });
   });
 
+  it('should fail on non-existing request user on before user inputs a request on /api/v1/requests/requestId/disapprove PUT', (done) => {
+    chai.request(app)
+      .put(`/api/v1/requests/${2}/disapprove`)
+      .set('x-access-token', token)
+      .end((err, res) => {
+        res.should.have.status(400);
+        res.should.be.json;
+        res.body.should.be.a('object');
+        res.body.should.have.property('status');
+        res.body.should.have.property('message');
+        res.body.status.should.equal('fail');
+
+        done();
+      });
+  });
+
   it('should login a user account on /api/v1/auth/login POST', (done) => {
     chai.request(app)
       .post('/api/v1/auth/login')
@@ -129,6 +145,8 @@ describe('Admin request API Tests', () => {
       });
   });
 
+  // Admin Approve Test
+
   it('should return fail on admin approve user requests with no token on /api/v1/requests/requestId/approve PUT', (done) => {
     chai.request(app)
       .put(`/api/v1/requests/${1}/approve`)
@@ -140,7 +158,7 @@ describe('Admin request API Tests', () => {
       });
   });
 
-  it('should return fail on fetch ALL user requests with invalid token on /api/v1/requests PUT', (done) => {
+  it('should return fail on approving a user requests with invalid token on /api/v1/requests/requestId/approve PUT', (done) => {
     chai.request(app)
       .put(`/api/v1/requests/${1}/approve`)
       .set('x-access-token', badToken)
@@ -152,7 +170,7 @@ describe('Admin request API Tests', () => {
       });
   });
 
-  it('should return on success on approve user requests with valid token on /api/v1/requests PUT', (done) => {
+  it('should return on success on approve user requests with valid token on /api/v1/requests/requestId/approve PUT', (done) => {
     chai.request(app)
       .put(`/api/v1/requests/${1}/approve`)
       .set('x-access-token', token)
@@ -167,7 +185,7 @@ describe('Admin request API Tests', () => {
       });
   });
 
-  it('should return on fail on already approved user requests with valid token on /api/v1/requests PUT', (done) => {
+  it('should return on fail on already approved user requests with valid token on /api/v1/requests/requestId/approve PUT', (done) => {
     chai.request(app)
       .put(`/api/v1/requests/${1}/approve`)
       .set('x-access-token', token)
@@ -182,9 +200,80 @@ describe('Admin request API Tests', () => {
       });
   });
 
-  it('should return on fail on non existing user requests with valid token on after user inputs a request on /api/v1/requests PUT', (done) => {
+  it('should return on fail on non existing user requests with valid token on after user inputs a request on /api/v1/requests/requestId/approve PUT', (done) => {
     chai.request(app)
       .put(`/api/v1/requests/${2}/approve`)
+      .set('x-access-token', token)
+      .end((err, res) => {
+        res.should.have.status(400);
+        res.should.be.json;
+        res.body.should.be.a('object');
+        res.body.should.have.property('status');
+        res.body.status.should.equal('fail');
+        res.body.should.have.property('message');
+        done();
+      });
+  });
+
+
+  // Disapprove Test
+
+  it('should return fail on admin disapprove user requests with no token on /api/v1/requests/requestId/disapprove PUT', (done) => {
+    chai.request(app)
+      .put(`/api/v1/requests/${1}/disapprove`)
+      .end((err, res) => {
+        res.should.have.status(401);
+        res.should.be.json;
+        res.body.should.have.property('message');
+        done();
+      });
+  });
+
+  it('should return fail on dispproving a request with invalid token on /api/v1/requests/requestId/disapprove PUT', (done) => {
+    chai.request(app)
+      .put(`/api/v1/requests/${1}/disapprove`)
+      .set('x-access-token', badToken)
+      .end((err, res) => {
+        res.should.have.status(401);
+        res.should.be.json;
+        res.body.should.have.property('message');
+        done();
+      });
+  });
+
+  it('should return on success on disapproving user requests with valid token on /api/v1/requests/requestId/disapprove PUT', (done) => {
+    chai.request(app)
+      .put(`/api/v1/requests/${1}/disapprove`)
+      .set('x-access-token', token)
+      .end((err, res) => {
+        res.should.have.status(200);
+        res.should.be.json;
+        res.body.should.be.a('object');
+        res.body.should.have.property('status');
+        res.body.status.should.equal('success');
+        res.body.should.have.property('message');
+        done();
+      });
+  });
+
+  it('should return on fail on already disapproved user request with valid token on /api/v1/requests/requestId/disapprove PUT', (done) => {
+    chai.request(app)
+      .put(`/api/v1/requests/${1}/disapprove`)
+      .set('x-access-token', token)
+      .end((err, res) => {
+        res.should.have.status(400);
+        res.should.be.json;
+        res.body.should.be.a('object');
+        res.body.should.have.property('status');
+        res.body.status.should.equal('fail');
+        res.body.should.have.property('message');
+        done();
+      });
+  });
+
+  it('should return on fail on non existing user requests with valid token on after user inputs a request on /api/v1/requests PUT', (done) => {
+    chai.request(app)
+      .put(`/api/v1/requests/${2}/disapprove`)
       .set('x-access-token', token)
       .end((err, res) => {
         res.should.have.status(400);


### PR DESCRIPTION
#### What does this PR do?
* Create an API endpoint to enable an admin disapprove a logged in user request

#### Description of Task to be completed?
* Admin should be able to disapprove a request that has either been approved or on pending through this API endpoint

#### How should this be manually tested?
* Clone the project to your local repository from git clone https://github.com/yomigeek/mtracker-app.git
* All necessary dependencies as stated in the README.md file should be installed
* run $ npm install
* Run app locally using $ npm run start
* Open the postman application and enter the URL http://localhost:5000/requests/:requestId/disapprove with PUT request method selected

* After the above is successful, you should get the following response: 
```
{
    "status": "success",
    "message": "This Request has been declined successfully!",
    "data": {
        "id": 3,
        "title": "Fridge fail to work",
        "description": "Fridge is faulty and doing bad greatly",
        "priority": "low"
    }
}
```
#### Any background context you want to provide?
To get the above response a request must have been created otherwise a response of no request exist, the below response will be displayed instead

```
{
    "status": 'fail',
    "message": 'Invalid Request Id',
}
```

####  What are the relevant pivotal tracker stories?
story type: feature
story id: 157754772

#### What are the relevant Github Issues?
None

#### Questions:
None

![admin_disapprove](https://user-images.githubusercontent.com/5827585/40671027-a514d0fc-6362-11e8-9e77-7dcc74338658.PNG)

