### PR TITLE
#158295996 Implement Admin Disapprove A Request

### DIFF
--- a/public/assets/js/fetchAdminARequest.js
+++ b/public/assets/js/fetchAdminARequest.js
@@ -91,7 +91,11 @@ function requestAction(actionType) {
       notification = htmlElementDisplay('approve-success', 'block');
 
   }
+  if (actionType == 2) {
+    fetchActionUrl = BASE_URL + '/api/v1/requests/'+ getRequestId + '/disapprove';
+    notification = htmlElementDisplay('approve-fail', 'block');
 
+  }
   innerHtmlDisplay('loader-img', '<img src="./assets/images/loader2.gif" class="loader-img" />');
   innerHtmlDisplay('loader', '...Approving Request...');
   htmlElementDisplay('request-details-box', 'none');


### PR DESCRIPTION
#### What does this PR do?
Implement Admin Disapprove Request

#### Description of Task to be completed?
Admin should be able to disapprove a user request

#### How should this be manually tested?
Go to the url https://mtrack-app.herokuapp.com/login.html
Enter the required credentials for the admin
If successful the admin dashboard page is displayed 
On the dashboard an admin clicks the View button
On the View request page an admin clicks on the decline request button
Admin gets notification on the request status

#### Any background context you want to provide?
None

####  What are the relevant pivotal tracker stories?
story type: feature
story id: 158295996

#### What are the relevant Github Issues?
None

#### Questions:
None
